### PR TITLE
feat: throw error when http result is higher than 400

### DIFF
--- a/src/sdk/Client.ts
+++ b/src/sdk/Client.ts
@@ -105,6 +105,9 @@ export class KonectyClient {
 					Authorization: `${this.#options.accessKey}`,
 				},
 			});
+			if (result.status >= 400) {
+				throw new Error(`${result.status} - ${result.statusText}`);
+			}
 
 			const body = await result.json();
 
@@ -128,6 +131,9 @@ export class KonectyClient {
 				},
 				body: JSON.stringify(serializeDates(data)),
 			});
+			if (result.status >= 400) {
+				throw new Error(`${result.status} - ${result.statusText}`);
+			}
 
 			const body = await result.json();
 
@@ -151,6 +157,9 @@ export class KonectyClient {
 				},
 				body: JSON.stringify(serializeDates({ ids, data })),
 			});
+			if (result.status >= 400) {
+				throw new Error(`${result.status} - ${result.statusText}`);
+			}
 
 			const body = await result.json();
 
@@ -173,6 +182,9 @@ export class KonectyClient {
 				},
 				body: JSON.stringify(serializeDates({ ids })),
 			});
+			if (result.status >= 400) {
+				throw new Error(`${result.status} - ${result.statusText}`);
+			}
 
 			const body = await result.json();
 
@@ -203,6 +215,9 @@ export class KonectyClient {
 				},
 				body: qs.stringify(loginPayload),
 			});
+			if (result.status >= 400) {
+				throw new Error(`${result.status} - ${result.statusText}`);
+			}
 
 			const body = (await result.json()) as KonectyLoginResult;
 
@@ -228,6 +243,9 @@ export class KonectyClient {
 					Authorization: `${this.#options.accessKey}`,
 				},
 			});
+			if (result.status >= 400) {
+				throw new Error(`${result.status} - ${result.statusText}`);
+			}
 
 			const body = await result.json();
 
@@ -252,6 +270,9 @@ export class KonectyClient {
 					Authorization: `${this.#options.accessKey}`,
 				},
 			});
+			if (result.status >= 400) {
+				throw new Error(`${result.status} - ${result.statusText}`);
+			}
 
 			const body = await result.json();
 


### PR DESCRIPTION
Throw a meaningful error message when the HTTP response status exceeds 400.

![Screenshot from 2022-07-08 16-39-59](https://user-images.githubusercontent.com/31394736/178059597-690f95ea-1a74-46fe-adcd-eae34dee44be.png)


Previously, it was throwing when trying to parse the body to JSON when there's no body, and so, giving a meaningless error message.

![Screenshot from 2022-07-08 16-36-12](https://user-images.githubusercontent.com/31394736/178059519-e7fbac38-c98b-44b6-be47-c0fd358d160a.png)

