### PR TITLE
fix: add errors field on get info

### DIFF
--- a/src/sdk/Client.ts
+++ b/src/sdk/Client.ts
@@ -77,6 +77,7 @@ export type KonectyLoginResult = {
 export type KonectyUserInfo = {
 	logged: boolean;
 	user?: User;
+	errors?: string[];
 };
 
 export type KonectyNextOnQueueResult = {
@@ -520,6 +521,7 @@ export class KonectyClient {
 			logger.error(err);
 			return {
 				logged: false,
+				errors: [(err as Error).message],
 			};
 		}
 	}


### PR DESCRIPTION
Pode acontecer um erro na request entre o SDK e o Konecty, entretanto isso não quer dizer que o usuário não está autenticado corretamente. Por isso, devemos retornar o erro que ocorreu permitindo que o app usando o SDK posso tratar o erro corretamente