### PR TITLE
fix(files-manager): delete files via /rest/file2 so legacy names work

### DIFF
--- a/src/__test__/sdk/FilesManager.test.ts
+++ b/src/__test__/sdk/FilesManager.test.ts
@@ -82,6 +82,40 @@ describe('FilesManager', () => {
       expect(result.success).toBe(true);
       expect(filesManager['files']).toHaveLength(0);
     });
+
+    it('should delete via /rest/file2 with the file name percent-encoded (legacy names with spaces/accents)', async () => {
+      (fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ success: true }),
+      });
+
+      (verifyResponseStatus as jest.Mock).mockResolvedValue(undefined);
+
+      await filesManager.deleteFile('Fachada comercial moderna com edifício residencial ao fundo.jpg');
+
+      expect(fetch).toHaveBeenCalledWith(
+        'http://localhost:3000/rest/file2/testObject/testRecordId/testFieldName/Fachada%20comercial%20moderna%20com%20edif%C3%ADcio%20residencial%20ao%20fundo.jpg',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+
+    it('should prefer recordCode over recordId on the delete URL, matching legacy storage keys', async () => {
+      (fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ success: true }),
+      });
+
+      (verifyResponseStatus as jest.Mock).mockResolvedValue(undefined);
+
+      filesManager = new FilesManager(konectyClientOpts, { ...recordData, recordCode: '5592', files: [fileConfig] });
+
+      await filesManager.deleteFile('testFile.txt');
+
+      expect(fetch).toHaveBeenCalledWith(
+        'http://localhost:3000/rest/file2/testObject/5592/testFieldName/testFile.txt',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
   });
 
   describe('reorder', () => {

--- a/src/__test__/utils/verifyResponseStatus.test.ts
+++ b/src/__test__/utils/verifyResponseStatus.test.ts
@@ -1,0 +1,36 @@
+import verifyResponseStatus from '../../utils/verifyResponseStatus';
+
+describe('verifyResponseStatus', () => {
+	it('should return the parsed body when the response is successful', async () => {
+		const response = {
+			status: 200,
+			json: jest.fn().mockResolvedValue({ success: true, data: [{ _id: 'id1' }] }),
+		} as unknown as Response;
+
+		await expect(verifyResponseStatus(response)).resolves.toEqual({ success: true, data: [{ _id: 'id1' }] });
+	});
+
+	it('should throw status and statusText for responses with status >= 400', async () => {
+		const response = { status: 404, statusText: 'Not Found' } as unknown as Response;
+
+		await expect(verifyResponseStatus(response)).rejects.toThrow('404 - Not Found');
+	});
+
+	it('should throw the joined messages when the body has errors[]', async () => {
+		const response = {
+			status: 200,
+			json: jest.fn().mockResolvedValue({ success: false, errors: [{ message: 'first' }, { message: 'second' }] }),
+		} as unknown as Response;
+
+		await expect(verifyResponseStatus(response)).rejects.toThrow('first, second');
+	});
+
+	it('should fall back to the singular error field when errors[] is absent (fileRemove format)', async () => {
+		const response = {
+			status: 200,
+			json: jest.fn().mockResolvedValue({ success: false, error: 'File with name [x] was not found' }),
+		} as unknown as Response;
+
+		await expect(verifyResponseStatus(response)).rejects.toThrow('File with name [x] was not found');
+	});
+});

--- a/src/sdk/FilesManager.ts
+++ b/src/sdk/FilesManager.ts
@@ -9,8 +9,11 @@ import verifyResponseStatus from '../utils/verifyResponseStatus';
 const endpoints = {
 	upload: ({ metaObject, recordId, recordCode, fieldName }: KonFiles.RecordData) =>
 		`rest/file/upload/ns/access/${metaObject}/${recordCode ?? recordId}/${fieldName}`,
+	// /rest/file2 instead of /rest/file/delete: the latter rejects decoded file names
+	// outside [a-zA-Z0-9_.-] (404 'Not found'), so legacy names with spaces/accents
+	// would never be deletable. file2 matches by decoded name and accepts _id or code.
 	delete: ({ metaObject, recordId, recordCode, fieldName }: KonFiles.RecordData, fileName: string) =>
-		`rest/file/delete/ns/access/${metaObject}/${recordCode ?? recordId}/${fieldName}/${fileName}`,
+		`rest/file2/${metaObject}/${recordCode ?? recordId}/${fieldName}/${encodeURIComponent(fileName)}`,
 };
 
 export class FilesManager {

--- a/src/utils/verifyResponseStatus.ts
+++ b/src/utils/verifyResponseStatus.ts
@@ -7,7 +7,8 @@ export default async function verifyResponseStatus<ResponseType extends Partial<
 
 	const responseData = (await response.json()) as ResponseType;
 	if (responseData.success === false) {
-		throw new Error(responseData.errors?.map(error => error.message).join(', '));
+		// fileRemove (and other core APIs) report failures with a singular `error` field
+		throw new Error(responseData.errors?.map(error => error.message).join(', ') ?? (responseData as { error?: string }).error);
 	}
 
 	return responseData;


### PR DESCRIPTION
## Problema

`FilesManager.deleteFile` monta a URL em `/rest/file/delete/ns/access/{document}/{recordCode ?? recordId}/{field}/{fileName}`. No backend atual (konecty/Konecty desde `ab8767d`, 2026-05-27) essa rota valida cada segmento **decodificado** contra `[a-zA-Z0-9_.-]` e responde `404 "Not found"` antes de remover o metadado — arquivos legados com espaços/acentos no nome (ex.: namespace foxter/hestia) ficam **indeletáveis** por essa rota, com qualquer encoding. Além disso o nome ia cru na URL (um `#`/`%`/`?` quebraria o path), e a deleção física de storage deriva do segmento do registro na URL, errando keys legadas geradas por `code`.

Sintoma na UI nova (`konecty/ui#47`): deletar imagem com nome acentuado → `404 Not found`, metadado intacto.

## Fix

- `deleteFile` agora usa `DELETE /rest/file2/{document}/{recordCode ?? recordId}/{fieldName}/{fileName}` — rota presente em todas as gerações do backend (era Meteor → HEAD), sem o guard de nomes, casa o arquivo pelo nome decodificado e aceita `_id` ou `code` — com o nome percent-encoded (`encodeURIComponent`).
- `verifyResponseStatus` passa a usar o campo `error` (singular) como fallback quando `errors[]` não vem — formato real do `fileRemove` (ex.: `File with name [x] was not found`), que antes virava `Error` com mensagem vazia.

## Testes

- Bug → test first: testes de reprodução commitados vermelhos (`3 failed`) antes do fix.
- Suíte completa verde: **78 passed, 22 suites**.

## Consumidor

O `konecty/ui` PR #47 será atualizado para consumir esta correção via bump de versão assim que ela for publicada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)