### PR TITLE
feat(auth): fluxo de login Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,63 @@ Documentação completa: [docs/README.md](./docs/README.md) (índice), [api.md](
 
 ---
 
+#### Login com Google
+
+O Konecty hospeda o fluxo de authorization code: o SDK apenas **monta** a URL de início,
+o browser é redirecionado para lá e, no retorno, o app troca o código de uso único
+(TTL de 60s) por uma sessão. O `authId` nunca transita em URL — ele só existe no corpo
+da resposta da troca, que deve ser feita no servidor do app.
+
+| Method               | Signature                                                                                      | Description                                                                  |
+| -------------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `getGoogleLoginUrl`  | `getGoogleLoginUrl(params: { clientId: string; redirectUri: string; state: string }): string`  | Monta a URL absoluta de `GET /api/auth/google/start`. Puro, não faz request. |
+| `exchangeGoogleCode` | `exchangeGoogleCode(code: string, extraData?: GoogleSessionExtraData): Promise<GoogleSession>` | Troca o código pelo `{ authId, user }` e adota o `authId` no cliente.        |
+| `getLoginOptions`    | `getLoginOptions(): Promise<LoginOptions>`                                                     | Flags de login habilitadas no servidor, incluindo `googleEnabled`.           |
+
+```ts
+import { KonectyClient } from '@konecty/sdk/Client';
+import crypto from 'crypto';
+
+const konecty = new KonectyClient({ endpoint: process.env.KONECTY_URL });
+
+// 1. Monte a URL de início (nenhum request de rede acontece aqui)
+const { googleEnabled } = await konecty.getLoginOptions();
+
+if (googleEnabled) {
+	const state = crypto.randomBytes(16).toString('hex'); // guarde na sessão do app
+	const url = konecty.getGoogleLoginUrl({
+		clientId: process.env.KONECTY_CLIENT_ID!,
+		redirectUri: 'https://app.exemplo.com/auth/google/callback',
+		state,
+	});
+
+	// 2. Redirecione o browser. O Konecty leva o usuário ao Google e devolve
+	//    o browser para o seu redirectUri com ?code=<uso unico>&state=<state>
+	//    (ou ?error=<codigo>&state=<state> em caso de recusa).
+	response.redirect(url);
+}
+
+// 3. No handler do seu callback (servidor do app): valide o state e troque o código
+async function handleCallback(query: { code?: string; error?: string; state?: string }) {
+	if (query.error != null) {
+		throw new Error(`Login recusado: ${query.error}`);
+	}
+	if (query.state !== expectedStateFromSession) {
+		throw new Error('State inválido');
+	}
+
+	// Em erro, lança com a mensagem de errors[0].message e o cliente segue não autenticado.
+	const { authId, user } = await konecty.exchangeGoogleCode(query.code!, {
+		source: 'web', // geolocation, resolution e fingerprint também são opcionais
+	});
+
+	// O cliente já está autenticado; os requests seguintes usam este authId.
+	const contacts = await konecty.find('Contact', { filter: {} });
+
+	return { authId, user, contacts };
+}
+```
+
 #### Files manager
 
 You can read the [full documentation here.](./docs/FilesManager.md)

--- a/src/__test__/api/googleLogin.test.ts
+++ b/src/__test__/api/googleLogin.test.ts
@@ -1,0 +1,233 @@
+import { KonectyClient } from '@konecty/sdk/Client';
+import { expect } from 'chai';
+
+import { rest } from 'msw';
+import { server } from '../../__test__/setup-test';
+
+const ENDPOINT = 'http://localhost:3000';
+
+const googleSessionResponse = {
+	success: true,
+	logged: true,
+	authId: 'not-a-real-auth-id',
+	user: {
+		_id: 'fake-user-id',
+		access: { defaults: ['Default'] },
+		admin: false,
+		email: 'jane.doe@example.invalid',
+		group: { _id: 'fake-group-id', name: 'Fake Group' },
+		locale: 'pt_BR',
+		login: 'jane.doe',
+		name: 'Jane Doe',
+		namespace: 'fake-namespace',
+		role: { _id: 'fake-role-id', name: 'Fake Role' },
+	},
+};
+
+describe('Konecty Google Login', () => {
+	describe('getGoogleLoginUrl', () => {
+		it('Should build the start URL with percent-encoded parameters', () => {
+			// Arrange
+			const konecty = new KonectyClient({ endpoint: ENDPOINT });
+
+			// Act
+			const url = konecty.getGoogleLoginUrl({
+				clientId: 'my app',
+				redirectUri: 'https://app.example.invalid/auth/callback?tenant=acme',
+				state: 'a b&c=d/e?f#g+h',
+			});
+
+			// Assert
+			expect(url).to.equal(
+				'http://localhost:3000/api/auth/google/start' +
+					'?client_id=my%20app' +
+					'&redirect_uri=https%3A%2F%2Fapp.example.invalid%2Fauth%2Fcallback%3Ftenant%3Dacme' +
+					'&state=a%20b%26c%3Dd%2Fe%3Ff%23g%2Bh',
+			);
+		});
+
+		it('Should not perform any network request', async () => {
+			// Arrange — the msw server is configured with onUnhandledRequest: 'error',
+			// so an accidental request would fail this test.
+			const konecty = new KonectyClient({ endpoint: ENDPOINT });
+
+			// Act
+			const url = konecty.getGoogleLoginUrl({
+				clientId: 'webapp',
+				redirectUri: 'https://app.example.invalid/cb',
+				state: 'opaque-state',
+			});
+
+			// Assert
+			expect(url).to.equal(
+				'http://localhost:3000/api/auth/google/start?client_id=webapp&redirect_uri=https%3A%2F%2Fapp.example.invalid%2Fcb&state=opaque-state',
+			);
+		});
+	});
+
+	describe('exchangeGoogleCode', () => {
+		it('Should return authId and user, and leave the client authenticated', async () => {
+			// Arrange
+			const konecty = new KonectyClient({ endpoint: ENDPOINT });
+			let receivedBody: Record<string, unknown> = {};
+			let authorizationOnNextRequest: string | null = null;
+
+			server.use(
+				rest.post(`${ENDPOINT}/api/auth/google/session`, async (req, res, ctx) => {
+					receivedBody = await req.json();
+					return res.once(ctx.status(200), ctx.json(googleSessionResponse));
+				}),
+				rest.get(`${ENDPOINT}/rest/data/Contact/find`, (req, res, ctx) => {
+					authorizationOnNextRequest = req.headers.get('authorization');
+					return res.once(ctx.status(200), ctx.json({ success: true, data: [], total: 0 }));
+				}),
+			);
+
+			// Act
+			const session = await konecty.exchangeGoogleCode('fake-single-use-code', {
+				geolocation: { longitude: -46.63, latitude: -23.55 },
+				resolution: { width: 1920, height: 1080 },
+				source: 'web',
+				fingerprint: 'fake-fingerprint',
+			});
+			await konecty.find('Contact', { filter: {} });
+
+			// Assert
+			expect(session.authId).to.equal(googleSessionResponse.authId);
+			expect(session.user).to.deep.equal(googleSessionResponse.user);
+			expect(session.user.namespace).to.equal('fake-namespace');
+			expect(konecty.options.accessKey).to.equal(googleSessionResponse.authId);
+			expect(authorizationOnNextRequest).to.equal(googleSessionResponse.authId);
+			expect(receivedBody).to.deep.equal({
+				code: 'fake-single-use-code',
+				geolocation: { longitude: -46.63, latitude: -23.55 },
+				resolution: { width: 1920, height: 1080 },
+				source: 'web',
+				fingerprint: 'fake-fingerprint',
+			});
+		});
+
+		it('Should send only the code when no extra data is given', async () => {
+			// Arrange
+			const konecty = new KonectyClient({ endpoint: ENDPOINT });
+			let receivedBody: Record<string, unknown> = {};
+
+			server.use(
+				rest.post(`${ENDPOINT}/api/auth/google/session`, async (req, res, ctx) => {
+					receivedBody = await req.json();
+					return res.once(ctx.status(200), ctx.json(googleSessionResponse));
+				}),
+			);
+
+			// Act
+			const session = await konecty.exchangeGoogleCode('fake-single-use-code');
+
+			// Assert
+			expect(receivedBody).to.deep.equal({ code: 'fake-single-use-code' });
+			expect(session.authId).to.equal(googleSessionResponse.authId);
+		});
+
+		it('Should throw the server error message and keep the client unauthenticated', async () => {
+			// Arrange
+			const konecty = new KonectyClient({ endpoint: ENDPOINT });
+			let authorizationOnNextRequest: string | null = null;
+
+			server.use(
+				rest.post(`${ENDPOINT}/api/auth/google/session`, (req, res, ctx) => {
+					return res.once(
+						ctx.status(400),
+						ctx.json({
+							success: false,
+							errors: [
+								{ message: 'Código de autenticação expirado', code: 'expired_code' },
+								{ message: 'Should not be used', code: 'invalid_code' },
+							],
+						}),
+					);
+				}),
+				rest.get(`${ENDPOINT}/rest/data/Contact/find`, (req, res, ctx) => {
+					authorizationOnNextRequest = req.headers.get('authorization');
+					return res.once(ctx.status(200), ctx.json({ success: true, data: [], total: 0 }));
+				}),
+			);
+
+			// Act
+			let thrown: Error | undefined;
+			try {
+				await konecty.exchangeGoogleCode('expired-fake-code');
+			} catch (err) {
+				thrown = err as Error;
+			}
+			await konecty.find('Contact', { filter: {} });
+
+			// Assert
+			expect(thrown).to.be.an('error');
+			expect(thrown?.message).to.equal('Código de autenticação expirado');
+			expect(konecty.options.accessKey).to.be.undefined;
+			expect(authorizationOnNextRequest).to.equal('undefined');
+		});
+
+		it('Should not adopt an authId when a previous session is active and the exchange fails', async () => {
+			// Arrange
+			const konecty = new KonectyClient({ endpoint: ENDPOINT, accessKey: 'previous-fake-auth-id' });
+
+			server.use(
+				rest.post(`${ENDPOINT}/api/auth/google/session`, (req, res, ctx) => {
+					return res.once(
+						ctx.status(400),
+						ctx.json({ success: false, errors: [{ message: 'Usuário inativo', code: 'user_inactive' }] }),
+					);
+				}),
+			);
+
+			// Act
+			let thrown: Error | undefined;
+			try {
+				await konecty.exchangeGoogleCode('fake-code-of-inactive-user');
+			} catch (err) {
+				thrown = err as Error;
+			}
+
+			// Assert
+			expect(thrown?.message).to.equal('Usuário inativo');
+			expect(konecty.options.accessKey).to.equal('previous-fake-auth-id');
+		});
+	});
+
+	describe('getLoginOptions', () => {
+		it('Should return the login option flags including googleEnabled', async () => {
+			// Arrange
+			const konecty = new KonectyClient({ endpoint: ENDPOINT });
+
+			server.use(
+				rest.get(`${ENDPOINT}/api/auth/login-options`, (req, res, ctx) => {
+					return res.once(
+						ctx.status(200),
+						ctx.json({
+							passwordEnabled: true,
+							emailOtpEnabled: false,
+							whatsAppOtpEnabled: false,
+							webauthnEnabled: true,
+							webauthnRequired: false,
+							googleEnabled: true,
+						}),
+					);
+				}),
+			);
+
+			// Act
+			const options = await konecty.getLoginOptions();
+
+			// Assert
+			expect(options).to.deep.equal({
+				passwordEnabled: true,
+				emailOtpEnabled: false,
+				whatsAppOtpEnabled: false,
+				webauthnEnabled: true,
+				webauthnRequired: false,
+				googleEnabled: true,
+			});
+			expect(options.googleEnabled).to.be.true;
+		});
+	});
+});

--- a/src/sdk/Client.ts
+++ b/src/sdk/Client.ts
@@ -10,6 +10,7 @@ import { PickFromPath, UnionToIntersection } from '@konecty/sdk/TypeUtils';
 import logger from '../lib/logger';
 import { deserializeDates, serializeDates } from '../utils/dateSerialization';
 import getGeolocation from '../utils/getGeolocation';
+import * as authDomain from './domains/auth';
 import * as changeUserDomain from './domains/changeUser';
 import * as commentsDomain from './domains/comments';
 import * as exportDomain from './domains/export';
@@ -725,6 +726,42 @@ export class KonectyClient {
 		}
 	}
 
+	/**
+	 * Builds the absolute URL of the Konecty-hosted Google login start endpoint.
+	 * Pure: no network request is made — send the browser to the returned URL.
+	 */
+	getGoogleLoginUrl(params: authDomain.GoogleLoginUrlParams): string {
+		return authDomain.getGoogleLoginUrl({ endpoint: this.#options.endpoint! }, params);
+	}
+
+	/**
+	 * Exchanges the single-use code from the app callback for a session and adopts
+	 * the returned `authId` on this client. On failure the authentication state is
+	 * left untouched and the error from the server is thrown.
+	 */
+	async exchangeGoogleCode(code: string, extraData?: authDomain.GoogleSessionExtraData): Promise<authDomain.GoogleSession> {
+		const session = await authDomain.exchangeGoogleCode(
+			{ endpoint: this.#options.endpoint!, accessKey: this.#options.accessKey },
+			code,
+			extraData,
+		);
+
+		this.#options.accessKey = session.authId;
+
+		if (isBrowser) {
+			Cookies.set('_authTokenId', session.authId);
+		}
+
+		return session;
+	}
+
+	async getLoginOptions(): Promise<authDomain.LoginOptions> {
+		return authDomain.getLoginOptions({
+			endpoint: this.#options.endpoint!,
+			accessKey: this.#options.accessKey,
+		});
+	}
+
 	async logout(): Promise<boolean> {
 		try {
 			const result = await fetch(`${this.#options.endpoint}/rest/auth/logout`, {
@@ -1149,3 +1186,13 @@ export class KonectyClient {
 }
 
 export type { KpiConfig, KpiResult } from './types/query';
+export type {
+	GoogleCallbackErrorCode,
+	GoogleLoginUrlParams,
+	GoogleSession,
+	GoogleSessionErrorCode,
+	GoogleSessionExtraData,
+	GoogleSessionResponse,
+	GoogleSessionUser,
+	LoginOptions,
+} from './domains/auth';

--- a/src/sdk/domains/auth.ts
+++ b/src/sdk/domains/auth.ts
@@ -1,0 +1,141 @@
+import fetch from 'isomorphic-fetch';
+
+import logger from '../../lib/logger';
+import { UserGroupType, UserLocaleType, UserRoleType } from '../User';
+
+export type AuthClientOptions = {
+	endpoint: string;
+	accessKey?: string;
+};
+
+export type GoogleLoginUrlParams = {
+	clientId: string;
+	redirectUri: string;
+	state: string;
+};
+
+/**
+ * Error codes the hosted callback may append to the app redirect_uri as `?error=<code>`.
+ */
+export type GoogleCallbackErrorCode =
+	| 'access_denied'
+	| 'provider_error'
+	| 'email_not_verified'
+	| 'user_not_found'
+	| 'user_inactive'
+	| 'ambiguous_user';
+
+/**
+ * Error codes returned by `POST /api/auth/google/session`.
+ */
+export type GoogleSessionErrorCode = 'invalid_code' | 'expired_code' | 'user_not_found' | 'user_inactive';
+
+export type GoogleSessionUser = {
+	_id: string;
+	access?: object;
+	admin?: boolean;
+	email?: string;
+	group?: UserGroupType;
+	locale?: UserLocaleType;
+	login?: string;
+	name?: string;
+	namespace?: string;
+	role?: UserRoleType;
+};
+
+export type GoogleSessionExtraData = {
+	geolocation?: { longitude: number; latitude: number };
+	resolution?: { width: number; height: number };
+	source?: string;
+	fingerprint?: string;
+};
+
+export type GoogleSession = {
+	authId: string;
+	user: GoogleSessionUser;
+};
+
+export type GoogleSessionResponse = {
+	success: boolean;
+	logged?: boolean;
+	authId?: string;
+	user?: GoogleSessionUser;
+	errors?: Array<{ message: string; code: GoogleSessionErrorCode | string }>;
+};
+
+export type LoginOptions = {
+	passwordEnabled: boolean;
+	emailOtpEnabled: boolean;
+	whatsAppOtpEnabled: boolean;
+	webauthnEnabled: boolean;
+	webauthnRequired: boolean;
+	googleEnabled: boolean;
+};
+
+/**
+ * Builds the absolute URL of the Konecty-hosted Google authorization start endpoint.
+ * Pure: performs no network request. The browser must be sent to this URL.
+ */
+export function getGoogleLoginUrl(opts: AuthClientOptions, params: GoogleLoginUrlParams): string {
+	const query = [
+		`client_id=${encodeURIComponent(params.clientId)}`,
+		`redirect_uri=${encodeURIComponent(params.redirectUri)}`,
+		`state=${encodeURIComponent(params.state)}`,
+	].join('&');
+
+	return `${opts.endpoint}/api/auth/google/start?${query}`;
+}
+
+/**
+ * Exchanges the single-use code received on the app callback for a session.
+ * The `authId` only ever travels in this response body — never in a URL.
+ */
+export async function exchangeGoogleCode(
+	opts: AuthClientOptions,
+	code: string,
+	extraData?: GoogleSessionExtraData,
+): Promise<GoogleSession> {
+	const url = `${opts.endpoint}/api/auth/google/session`;
+
+	const res = await fetch(url, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(Object.assign({ code }, extraData ?? {})),
+	});
+
+	const body = (await parseJsonBody(res)) as GoogleSessionResponse | null;
+
+	if (res.status >= 400 || body?.success !== true || body?.authId == null || body?.user == null) {
+		const message = body?.errors?.[0]?.message ?? `${res.status} - ${res.statusText}`;
+		logger.error(`${res.status} ${res.statusText}`, { url, message });
+		throw new Error(message);
+	}
+
+	return { authId: body.authId, user: body.user };
+}
+
+export async function getLoginOptions(opts: AuthClientOptions): Promise<LoginOptions> {
+	const url = `${opts.endpoint}/api/auth/login-options`;
+
+	const res = await fetch(url, {
+		method: 'GET',
+		headers: { Authorization: opts.accessKey ?? '' },
+	});
+
+	if (res.status >= 400) {
+		const errBody = await res.text();
+		logger.error(`${res.status} ${res.statusText}`, { url, body: errBody });
+		throw new Error(`${res.status} - ${res.statusText}`);
+	}
+
+	return res.json() as Promise<LoginOptions>;
+}
+
+async function parseJsonBody(res: Response): Promise<unknown | null> {
+	try {
+		return await res.json();
+	} catch (err) {
+		logger.error(err);
+		return null;
+	}
+}


### PR DESCRIPTION
## O que é

Suporte ao login com Google recém-adicionado ao core (konecty/Konecty#479), que usa **authorization code hospedado pelo Konecty**. O app nunca fala com o Google nem manipula `client_secret`.

Como o fluxo é de redirect, o SDK **não** recebe `id_token`: ele monta a URL de início e, no callback do app, troca o código pela sessão.

```ts
// 1. no servidor do app: montar a URL e redirecionar o browser
const url = client.getGoogleLoginUrl({ clientId: 'meu-app', redirectUri: 'https://app/cb', state })

// 2. o Konecty redireciona de volta para https://app/cb?code=...&state=...

// 3. no servidor do app: trocar o código pela sessão
const { authId, user } = await client.exchangeGoogleCode(code)
// o cliente já está autenticado a partir daqui
```

## API

| Método | Rede | O que faz |
|---|---|---|
| `getGoogleLoginUrl({ clientId, redirectUri, state })` | não | monta a URL absoluta de `GET /api/auth/google/start`, percent-encoded. Função pura. |
| `exchangeGoogleCode(code, extraData?)` | `POST /api/auth/google/session` | retorna `{ authId, user }` e **adota** o `authId` no cliente |
| `getLoginOptions()` | `GET /api/auth/login-options` | flags tipadas, incluindo `googleEnabled` |

`extraData` aceita a telemetria opcional que o core registra no AccessLog (`geolocation`, `resolution`, `source`, `fingerprint`).

Segue as convenções que já existem no repo: novo domínio `src/sdk/domains/auth.ts` no mesmo formato de `changeUser`/`notifications` (`{ endpoint, accessKey }`, `isomorphic-fetch`, `logger.error` em falha), com 3 métodos delegando em `Client.ts`. O diff em `Client.ts` é **puramente aditivo** (+47/-0).

## Detalhe de segurança que o SDK preserva

O `authId` **nunca transita em URL** — o callback devolve um código de uso único (TTL 60s) e o token de sessão só existe no corpo do `POST /session`. O README documenta isso.

## Testes

**72 → 79 testes**, todos verdes (`npx jest --detectOpenHandles --runInBand`). Nada deletado ou pulado. msw + chai, no estilo de `src/__test__/api/info.test.ts`.

O que os testes travam:

- URL montada comparada por **string exata**, incluindo um `state` com `a b&c=d/e?f#g+h` e um `redirectUri` que já tem query.
- Caminho feliz: além de `{ authId, user }`, um handler msw captura o header `Authorization` **efetivamente enviado** numa chamada `find` posterior — prova que a sessão foi adotada de verdade, não só que o campo foi setado.
- Caminho de erro: lança com `errors[0].message` **e** o `accessKey` permanece `undefined`, **e** a requisição seguinte não leva token. Um segundo caso prova que um `accessKey` pré-existente fica intacto.
- Body com e sem telemetria.

## Nota para revisão

Encoding: usei `encodeURIComponent` por parâmetro em vez de `URLSearchParams`, porque este último codifica espaço como `+`. Aqui espaço vira `%20`. **O SDK Python usa `quote_plus` e portanto `+`** — ambos válidos e funcionalmente equivalentes no lado do Konecty (e um `+` literal vira `%2B` nos dois), mas é uma divergência cosmética entre os SDKs. A string exata está travada em teste nos dois repos; alinhar é um one-liner se preferirem uniformidade.

Em sucesso, no browser, também seta o cookie `_authTokenId`, exatamente como o `login()` existente.

Depende de konecty/Konecty#479 estar mergeado e do namespace ter `googleConfig` configurado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)